### PR TITLE
Fix in-world preview not disappearing after a timeout

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/client/ForgeClientEventListener.java
+++ b/src/main/java/com/lowdragmc/mbd2/client/ForgeClientEventListener.java
@@ -8,6 +8,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RegisterClientCommandsEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -35,5 +36,10 @@ public class ForgeClientEventListener {
             // transparent blocks.
             MultiblockInWorldPreviewRenderer.renderInWorldPreview(event.getPoseStack(), event.getCamera(), event.getPartialTick());
         }
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        MultiblockInWorldPreviewRenderer.onClientTick();
     }
 }


### PR DESCRIPTION
## Description
The `MultiblockInWorldPreviewRenderer#onClientTick` was never called. Hence, the in-world preview never disappeared as the timer never decremented.
This PR registers a client tick event and calls the method mentioned above.