### PR TITLE
Fix some issues with language keys

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/NaturesAuraRecipeCapability.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/NaturesAuraRecipeCapability.java
@@ -57,7 +57,7 @@ public class NaturesAuraRecipeCapability extends RecipeCapability<Integer> {
 
     @Override
     public void createContentConfigurator(ConfiguratorGroup father, Supplier<Integer> supplier, Consumer<Integer> onUpdate) {
-        father.addConfigurators(new NumberConfigurator("recipe.capability.natures_aura.aura", supplier::get,
+        father.addConfigurators(new NumberConfigurator("recipe.capability.natures_aura.aura_name", supplier::get,
                 number -> onUpdate.accept(number.intValue()), 1, true).setRange(1, Integer.MAX_VALUE));
     }
 

--- a/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/trait/AuraHandlerTraitDefinition.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/trait/AuraHandlerTraitDefinition.java
@@ -25,7 +25,7 @@ public class AuraHandlerTraitDefinition extends RecipeCapabilityTraitDefinition 
 
     @Getter
     @Setter
-    @Configurable(name = "config.definition.trait.aura_handler.radius", tips = "config.definition.trait.aura_handler.radius.tips")
+    @Configurable(name = "config.definition.trait.aura_handler.radius", tips = "config.definition.trait.aura_handler.radius.tooltip")
     @NumberRange(range = {1, 64})
     private int radius = 20;
 

--- a/src/main/resources/assets/mbd2/lang/en_us.json
+++ b/src/main/resources/assets/mbd2/lang/en_us.json
@@ -672,6 +672,7 @@
 
     "recipe.capability.natures_aura.name": "Nature's Aura Capability",
     "recipe.capability.natures_aura.aura": "Nature's Aura: %s",
+    "recipe.capability.natures_aura.aura_name": "Nature's Aura",
 
     "recipe.capability.pneumatic_pressure_air.name": "Pneumatic Pressure Air Capability",
     "recipe.capability.pneumatic_pressure_air.type": "Type",

--- a/src/main/resources/assets/mbd2/lang/zh_cn.json
+++ b/src/main/resources/assets/mbd2/lang/zh_cn.json
@@ -672,6 +672,7 @@
 
     "recipe.capability.natures_aura.name": "自然灵气 - 灵气",
     "recipe.capability.natures_aura.aura": "灵气：%s",
+    "recipe.capability.natures_aura.aura_name": "灵气",
 
     "recipe.capability.pneumatic_pressure_air.name": "气动工艺 - 压力",
     "recipe.capability.pneumatic_pressure_air.type": "类型",


### PR DESCRIPTION
need to add a new lang key because `recipe.capability.natures_aura.aura` has a variable `(%s)` and therefore cannot be used directly
dang
![image](https://github.com/user-attachments/assets/f5023c28-c2ad-43d2-9086-7996ee306f63)

Fixed the aura radius setting tips referenced an incorrect lang key in the trait definition
![image](https://github.com/user-attachments/assets/46d182fa-4402-4e40-8e70-10f7b15d8f88)
