### PR TITLE
set op permission for mbd2 commands

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/client/ClientCommands.java
+++ b/src/main/java/com/lowdragmc/mbd2/client/ClientCommands.java
@@ -30,6 +30,7 @@ public class ClientCommands {
     public static List<LiteralArgumentBuilder<CommandSourceStack>> createClientCommands() {
         return List.of(
                 Commands.literal("mbd2_editor")
+                        .requires(s -> s.hasPermission(2))
                         .executes(context -> {
                             var holder = new IUIHolder() {
                                 @Override

--- a/src/main/java/com/lowdragmc/mbd2/common/ServerCommands.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/ServerCommands.java
@@ -18,6 +18,7 @@ public class ServerCommands {
     public static List<LiteralArgumentBuilder<CommandSourceStack>> createServerCommands() {
         return List.of(
                 Commands.literal("mbd2")
+                        .requires(s -> s.hasPermission(2))
                         .then(Commands.literal("reload_machine_projects")
                                 .executes(context -> {
                                     // clear up the catalyst candidates

--- a/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/NaturesAuraRecipeCapability.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/NaturesAuraRecipeCapability.java
@@ -57,7 +57,7 @@ public class NaturesAuraRecipeCapability extends RecipeCapability<Integer> {
 
     @Override
     public void createContentConfigurator(ConfiguratorGroup father, Supplier<Integer> supplier, Consumer<Integer> onUpdate) {
-        father.addConfigurators(new NumberConfigurator("recipe.capability.natures_aura.aura", supplier::get,
+        father.addConfigurators(new NumberConfigurator("recipe.capability.natures_aura.aura_name", supplier::get,
                 number -> onUpdate.accept(number.intValue()), 1, true).setRange(1, Integer.MAX_VALUE));
     }
 

--- a/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/trait/AuraHandlerTraitDefinition.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/naturesaura/trait/AuraHandlerTraitDefinition.java
@@ -25,7 +25,7 @@ public class AuraHandlerTraitDefinition extends RecipeCapabilityTraitDefinition 
 
     @Getter
     @Setter
-    @Configurable(name = "config.definition.trait.aura_handler.radius", tips = "config.definition.trait.aura_handler.radius.tips")
+    @Configurable(name = "config.definition.trait.aura_handler.radius", tips = "config.definition.trait.aura_handler.radius.tooltip")
     @NumberRange(range = {1, 64})
     private int radius = 20;
 

--- a/src/main/resources/assets/mbd2/lang/en_us.json
+++ b/src/main/resources/assets/mbd2/lang/en_us.json
@@ -672,6 +672,7 @@
 
     "recipe.capability.natures_aura.name": "Nature's Aura Capability",
     "recipe.capability.natures_aura.aura": "Nature's Aura: %s",
+    "recipe.capability.natures_aura.aura_name": "Nature's Aura",
 
     "recipe.capability.pneumatic_pressure_air.name": "Pneumatic Pressure Air Capability",
     "recipe.capability.pneumatic_pressure_air.type": "Type",

--- a/src/main/resources/assets/mbd2/lang/zh_cn.json
+++ b/src/main/resources/assets/mbd2/lang/zh_cn.json
@@ -672,6 +672,7 @@
 
     "recipe.capability.natures_aura.name": "自然灵气 - 灵气",
     "recipe.capability.natures_aura.aura": "灵气：%s",
+    "recipe.capability.natures_aura.aura_name": "灵气",
 
     "recipe.capability.pneumatic_pressure_air.name": "气动工艺 - 压力",
     "recipe.capability.pneumatic_pressure_air.type": "类型",


### PR DESCRIPTION
set op permissions for the mbd2 commands to prevent players execute it without op permissions