### PR TITLE
set op permission for mbd2 commands

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/client/ClientCommands.java
+++ b/src/main/java/com/lowdragmc/mbd2/client/ClientCommands.java
@@ -30,6 +30,7 @@ public class ClientCommands {
     public static List<LiteralArgumentBuilder<CommandSourceStack>> createClientCommands() {
         return List.of(
                 Commands.literal("mbd2_editor")
+                        .requires(s -> s.hasPermission(2))
                         .executes(context -> {
                             var holder = new IUIHolder() {
                                 @Override

--- a/src/main/java/com/lowdragmc/mbd2/common/ServerCommands.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/ServerCommands.java
@@ -18,6 +18,7 @@ public class ServerCommands {
     public static List<LiteralArgumentBuilder<CommandSourceStack>> createServerCommands() {
         return List.of(
                 Commands.literal("mbd2")
+                        .requires(s -> s.hasPermission(2))
                         .then(Commands.literal("reload_machine_projects")
                                 .executes(context -> {
                                     // clear up the catalyst candidates


### PR DESCRIPTION
set op permissions for the mbd2 commands to prevent players execute it without op permissions