### PR TITLE
Fixed predicate tag not persisting and resources not renaming

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/api/pattern/predicates/PredicateTags.java
+++ b/src/main/java/com/lowdragmc/mbd2/api/pattern/predicates/PredicateTags.java
@@ -5,6 +5,7 @@ import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
 import com.lowdragmc.lowdraglib.gui.editor.configurator.ArrayConfiguratorGroup;
 import com.lowdragmc.lowdraglib.gui.editor.configurator.ConfiguratorGroup;
 import com.lowdragmc.lowdraglib.gui.editor.configurator.SearchComponentConfigurator;
+import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.utils.BlockInfo;
 import lombok.NoArgsConstructor;
 import net.minecraft.core.Holder;
@@ -23,6 +24,7 @@ import java.util.Objects;
 @NoArgsConstructor
 public class PredicateTags extends SimplePredicate {
 
+    @Persisted
     protected ResourceLocation[] tags = new ResourceLocation[] {};
 
     public PredicateTags(ResourceLocation... tags) {

--- a/src/main/java/com/lowdragmc/mbd2/common/gui/editor/PredicateResourceContainer.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/gui/editor/PredicateResourceContainer.java
@@ -68,13 +68,14 @@ public class PredicateResourceContainer extends ResourceContainer<SimplePredicat
                 if (s == null || selected.equals(s)) return;
                 var stored =  resource.removeResource(selected);
                 resource.addResource(s, stored);
+                var prevName = selected; // selected is set to null on rebuild
                 reBuild();
                 if (Editor.INSTANCE.getCurrentProject() instanceof MultiblockMachineProject project) {
                     boolean changed = false;
                     for (var x : project.getBlockPlaceholders()) {
                         for (var y : x) {
                             for (var z : y) {
-                                if (z.getPredicates().remove(selected)) {
+                                if (z.getPredicates().remove(prevName)) {
                                     z.getPredicates().add(s);
                                     changed = true;
                                 }


### PR DESCRIPTION
## Description
This PR fixes two issues which I've encountered when working with predicates:
- `PredicateTags` not persisting the `tags` field, meaning it gets reset every time to the default value (sand tag)
- Block predicates aren't renaming after resource renaming because the `selected` field gets reset on `reBuild` call, meaning the whole renaming block predicates process was never called

## Approaches
- The `tags` field was annotated with `@Persisted` as seen throughout the codebase. Not sure this is the best/correct way, lemme know how you feel about that
- The `selected` field is assigned to a local variable immediately before `reBuild` call so it can be used afterwards safely