### PR TITLE
Fixed `MDBRecipeSchema#chance` not restoring previous chance

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/kubejs/recipe/MBDRecipeSchema.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/kubejs/recipe/MBDRecipeSchema.java
@@ -138,7 +138,7 @@ public interface MBDRecipeSchema {
             var lastChance = this.chance;
             this.chance = chance;
             builder.accept(this);
-            this.chance = chance;
+            this.chance = lastChance;
             return this;
         }
 


### PR DESCRIPTION
## Description
Tiny PR to fix typo, which leads to not restoring chance from the `lastChance` variable.