### PR TITLE
Make block predicates sortable

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/gui/editor/multiblock/BlockPlaceholder.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/gui/editor/multiblock/BlockPlaceholder.java
@@ -22,7 +22,7 @@ public class BlockPlaceholder implements IConfigurable, ITagSerializable<Compoun
     @Getter
     protected final PredicateResource predicateResource;
     @Getter
-    protected Set<String> predicates = new HashSet<>();
+    protected Set<String> predicates = new LinkedHashSet<>();
     @Getter
     @Setter
     protected boolean isController;

--- a/src/main/java/com/lowdragmc/mbd2/common/gui/editor/multiblock/MultiblockPatternPanel.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/gui/editor/multiblock/MultiblockPatternPanel.java
@@ -177,7 +177,7 @@ public class MultiblockPatternPanel extends WidgetGroup {
         @Override
         public void buildConfigurator(ConfiguratorGroup father) {
             var placeholders =  selectedBlocks.stream().map(pos -> project.getBlockPlaceholders()[pos.x][pos.y][pos.z]).toList();
-            var intersection = new ArrayList<>(placeholders.get(0).getPredicates());
+            var intersection = new LinkedList<>(placeholders.get(0).getPredicates());
             Runnable notifyUpdate = () -> placeholders.forEach(holder -> {
                 var predicates = holder.getPredicates();
                 predicates.clear();
@@ -232,6 +232,7 @@ public class MultiblockPatternPanel extends WidgetGroup {
                 intersection.addAll(values);
                 notifyUpdate.run();
             });
+            predicatesConfigurator.setOnReorder((index, value) -> predicatesConfigurator.notifyListUpdate());
             father.addConfigurators(predicatesConfigurator);
         }
     }


### PR DESCRIPTION
## Description
This PR adds great QoL feature I was missing recently - block predicates sorting.
This allows to define exact order of predicates in XEI, which is useful to demonstrate necessary blocks in the initial multiblock preview without having to click through all blocks.