### PR TITLE
Fix auto builder consuming items preemptively + lang fixes

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/api/pattern/error/SinglePredicateError.java
+++ b/src/main/java/com/lowdragmc/mbd2/api/pattern/error/SinglePredicateError.java
@@ -36,6 +36,6 @@ public class SinglePredicateError extends PatternError {
         if (type == 3) {
             number = predicate.minLayerCount;
         }
-        return Component.translatable("MBD2.multiblock.pattern.error.limited." + type, number);
+        return Component.translatable("mbd2.multiblock.pattern.error.limited." + type, number);
     }
 }


### PR DESCRIPTION
## Description
This PR introduces enhancements to auto builder, as well as some lang fixes.

### Auto builder enhancements
Currently, auto builder consumes items before trying whether it can place a block/fluid at said position at all.
This PR addresses this issue by deferring stack modification until all checks pass successfully (block or fluid placed).

### Langs fixes
In `SinglePredicateError`, lang key `MBD2.multiblock.pattern.error.limited.X` is incorrect due to capitalized mod id.
This PR makes mod id lowercased.