### PR TITLE
Added energy formatting

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/capability/recipe/ForgeEnergyRecipeCapability.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/capability/recipe/ForgeEnergyRecipeCapability.java
@@ -11,6 +11,7 @@ import com.lowdragmc.mbd2.api.capability.recipe.RecipeCapability;
 import com.lowdragmc.mbd2.api.recipe.content.Content;
 import com.lowdragmc.mbd2.api.recipe.content.SerializerInteger;
 import com.lowdragmc.mbd2.common.gui.recipe.CornerNumberWidget;
+import com.lowdragmc.mbd2.utils.EnergyFormattingUtil;
 import net.minecraft.network.chat.Component;
 
 import java.util.List;
@@ -53,12 +54,12 @@ public class ForgeEnergyRecipeCapability extends RecipeCapability<Integer> {
     @Override
     public void bindXEIWidget(Widget widget, Content content, IngredientIO ingredientIO) {
         if (widget instanceof ProgressWidget energyBar) {
-            var energy = of(content.content);
+            var energy = EnergyFormattingUtil.formatExtended(of(content.content));
             if (energyBar.getOverlay() instanceof TextTexture textTexture) {
                 if (content.perTick) {
-                    textTexture.updateText(energy + " FE/t");
+                    textTexture.updateText(energy + "FE/t");
                 } else {
-                    textTexture.updateText(energy + " FE");
+                    textTexture.updateText(energy + "FE");
                 }
             }
         }

--- a/src/main/java/com/lowdragmc/mbd2/common/trait/forgeenergy/ForgeEnergyCapabilityTraitDefinition.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/trait/forgeenergy/ForgeEnergyCapabilityTraitDefinition.java
@@ -17,6 +17,7 @@ import com.lowdragmc.mbd2.common.trait.ITrait;
 import com.lowdragmc.mbd2.common.trait.SimpleCapabilityTrait;
 import com.lowdragmc.mbd2.common.trait.SimpleCapabilityTraitDefinition;
 import com.lowdragmc.mbd2.common.trait.ToggleAutoIO;
+import com.lowdragmc.mbd2.utils.EnergyFormattingUtil;
 import com.lowdragmc.mbd2.utils.WidgetUtils;
 import lombok.Getter;
 import lombok.Setter;
@@ -86,12 +87,18 @@ public class ForgeEnergyCapabilityTraitDefinition extends SimpleCapabilityTraitD
             var prefix = uiPrefixName();
             WidgetUtils.widgetByIdForEach(group, "^%s$".formatted(prefix), ProgressWidget.class, energyBar -> {
                 energyBar.setProgressSupplier(() -> forgeEnergyTrait.storage.getEnergyStored() * 1d / forgeEnergyTrait.storage.getMaxEnergyStored());
-                energyBar.setDynamicHoverTips(value -> LocalizationUtils.format(
-                        "config.definition.trait.forge_energy_storage.ui_container_hover",
-                        Math.round(forgeEnergyTrait.storage.getMaxEnergyStored() * value), forgeEnergyTrait.storage.getMaxEnergyStored()));
+                energyBar.setDynamicHoverTips(value -> {
+                    var stored = EnergyFormattingUtil.formatExtended(Math.round(forgeEnergyTrait.storage.getMaxEnergyStored() * value));
+                    var maxStored = EnergyFormattingUtil.formatExtended(forgeEnergyTrait.storage.getMaxEnergyStored());
+                    return LocalizationUtils.format("config.definition.trait.forge_energy_storage.ui_container_hover", stored, maxStored);
+                });
             });
             WidgetUtils.widgetByIdForEach(group, "^%s_text$".formatted(prefix), TextTextureWidget.class, energyBarText -> {
-                energyBarText.setText(() -> Component.literal(forgeEnergyTrait.storage.getEnergyStored() + "/" + forgeEnergyTrait.storage.getMaxEnergyStored() + " FE"));
+                energyBarText.setText(() -> {
+                    var stored = EnergyFormattingUtil.formatCompact(forgeEnergyTrait.storage.getEnergyStored()) + "FE";
+                    var maxStored = EnergyFormattingUtil.formatCompact(forgeEnergyTrait.storage.getMaxEnergyStored()) + "FE";
+                    return Component.literal(stored + "/" + maxStored);
+                });
             });
         }
     }

--- a/src/main/java/com/lowdragmc/mbd2/utils/EnergyFormattingUtil.java
+++ b/src/main/java/com/lowdragmc/mbd2/utils/EnergyFormattingUtil.java
@@ -1,0 +1,27 @@
+package com.lowdragmc.mbd2.utils;
+
+import java.text.DecimalFormat;
+
+public class EnergyFormattingUtil {
+    private static final DecimalFormat COMPACT_FORMAT = new DecimalFormat("#.##");
+    private static final String[] SUFFIXES = {"", "k", "M", "G"};
+
+    public static String formatExtended(long number) {
+        return String.format("%,d", number).replace(",", ".");
+    }
+
+    public static String formatCompact(long number) {
+        if (number < 1000) {
+            return String.valueOf(number);
+        }
+
+        var exp = (int) (Math.log10(number) / 3);
+        if (exp >= SUFFIXES.length) {
+            exp = SUFFIXES.length - 1;
+        }
+
+        var value = number / Math.pow(1000, exp);
+
+        return COMPACT_FORMAT.format(value).replace(",", ".") + SUFFIXES[exp];
+    }
+}

--- a/src/main/resources/assets/mbd2/lang/en_us.json
+++ b/src/main/resources/assets/mbd2/lang/en_us.json
@@ -435,7 +435,7 @@
     "config.definition.trait.forge_energy_storage.max_receive.tooltip": "Max received energy per action.",
     "config.definition.trait.forge_energy_storage.max_extract": "Max Extract",
     "config.definition.trait.forge_energy_storage.max_extract.tooltip": "Max extracted energy per action.",
-    "config.definition.trait.forge_energy_storage.ui_container_hover": "Stored: %d / %d FE",
+    "config.definition.trait.forge_energy_storage.ui_container_hover": "Stored: %dFE / %dFE",
     "config.definition.trait.forge_energy_storage.auto_io.tooltip": "Auto extract from the nearby energy storage or fill to the nearby energy storage.",
     "config.definition.trait.forge_energy_storage.fancy_renderer": "Fancy Forge Storage Renderer",
     "config.definition.trait.forge_energy_storage.fancy_renderer.tooltip": "Allow you render stored energy in the world. (e.g. Energy Container).",


### PR DESCRIPTION
## Description
When dealing with recipes that require a lot of energy, you end up seeing numbers like this:

**Machine energy storage**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0387d7f3-f463-4a13-ba45-b103717b0900" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f51624f0-a822-41b9-99fb-18b53066d060" />
**Recipe preview**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a3d71f7f-2c59-4b75-9613-c1dd11a42b5b" />

This makes it hard to understand what number is presented.

## Solution
Different mods implement different formatting styles, most notably "compact" and "extended".

### Compact style
Compact style is using mutually agreed energy suffixes, like `k`, `M`, `G`, etc. This is what it looks like:

**Machine energy storage**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/10aa1fc5-22cd-4434-9231-d419c7c89a9e" />

### Extended style
Extended style is basically adding separators between thousands using dot notation. This is what it looks like:

**Machine energy storage**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ef410e6e-f664-499c-88bc-f6b212f0ca42" />
**Recipe preview**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1ac93a59-e4cb-4a5e-9418-e9c480b1e5e2" />