### PR TITLE
Trait Capability IO Override

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/trait/SimpleCapabilityTrait.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/trait/SimpleCapabilityTrait.java
@@ -6,6 +6,7 @@ import net.minecraft.core.Direction;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class SimpleCapabilityTrait extends RecipeCapabilityTrait {
+    public CapabilityIO getCapabilityIOOverride = null;
 
     public SimpleCapabilityTrait(MBDMachine machine, SimpleCapabilityTraitDefinition definition) {
         super(machine, definition);
@@ -16,9 +17,10 @@ public abstract class SimpleCapabilityTrait extends RecipeCapabilityTrait {
         return (SimpleCapabilityTraitDefinition)super.getDefinition();
     }
 
-    public IO getCapabilityIO(@Nullable Direction side) {
+    public IO CapabilityIO (@Nullable Direction side) {
         var front = getMachine().getFrontFacing().orElse(Direction.NORTH);
-        return getDefinition().getCapabilityIO().getIO(front, side);
+        var IO = getCapabilityIOOverride == null ? getDefinition().getCapabilityIO() : getCapabilityIOOverride;
+        return IO.getIO(front, side);
     }
 
 }

--- a/src/main/java/com/lowdragmc/mbd2/common/trait/SimpleCapabilityTrait.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/trait/SimpleCapabilityTrait.java
@@ -17,7 +17,7 @@ public abstract class SimpleCapabilityTrait extends RecipeCapabilityTrait {
         return (SimpleCapabilityTraitDefinition)super.getDefinition();
     }
 
-    public IO CapabilityIO (@Nullable Direction side) {
+    public IO getCapabilityIO(@Nullable Direction side) {
         var front = getMachine().getFrontFacing().orElse(Direction.NORTH);
         var IO = getCapabilityIOOverride == null ? getDefinition().getCapabilityIO() : getCapabilityIOOverride;
         return IO.getIO(front, side);


### PR DESCRIPTION
Allows dynamically overriding the capability IO on machine traits.
It is not persistent, I do not know how to make it persistent, but it would make since if it was.

example script
```js
const $CapabilityIO = Java.loadClass("com.lowdragmc.mbd2.common.trait.CapabilityIO");

MBDMachineEvents.onRightClick("mbd2:diamond_machine", e => {
    let event = e.getEvent();
    event.getMachine().getTraitByName("item_slot").getCapabilityIOOverride = new $CapabilityIO();
    event.getMachine().getTraitByName("item_slot").getCapabilityIOOverride.topIO = $IO.IN;
});
```