### PR TITLE
Fixed `Invalid number of arguments` exception

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/machine/MBDMachine.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/machine/MBDMachine.java
@@ -912,7 +912,7 @@ public class MBDMachine implements IMachine, IEnhancedManaged, ICapabilityProvid
                     machineFX.start();
                 }
             } else {
-                rpcToTracking("emitPhotonFx", identifier, fxLocation, offset, rotation, delay, forcedDeath);
+                rpcToTracking("emitPhotonFx", identifier, fxLocation, offset, rotation, delay, forcedDeath, replaceExisting);
             }
         }
     }


### PR DESCRIPTION
## Description
Emitting Photon FX produces an exception: `Invalid number of arguments, expected 7 but got 6`

Thanks @lentel27 for spotting the issue