### PR TITLE
fix multiblock preview does not show block predicates with EMI and REI

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/emi/MultiblockInfoEmiCategory.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/emi/MultiblockInfoEmiCategory.java
@@ -1,6 +1,7 @@
 package com.lowdragmc.mbd2.integration.emi;
 
 import com.lowdragmc.lowdraglib.emi.ModularEmiRecipe;
+import com.lowdragmc.lowdraglib.gui.widget.SlotWidget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 import com.lowdragmc.mbd2.MBD2;
 import com.lowdragmc.mbd2.api.pattern.PatternPreviewWidget;
@@ -33,6 +34,11 @@ public class MultiblockInfoEmiCategory extends EmiRecipeCategory {
         @Override
         public @Nullable ResourceLocation getId() {
             return definition.id();
+        }
+
+        @Override
+        public void clearSlotWidgetHandler(SlotWidget slotW, int slotIndex) {
+            slotW.setDrawHoverOverlay(false);
         }
     }
 

--- a/src/main/java/com/lowdragmc/mbd2/integration/rei/MultiblockInfoDisplayCategory.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/rei/MultiblockInfoDisplayCategory.java
@@ -1,6 +1,7 @@
 package com.lowdragmc.mbd2.integration.rei;
 
 import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
+import com.lowdragmc.lowdraglib.gui.widget.SlotWidget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 import com.lowdragmc.lowdraglib.rei.IGui2Renderer;
 import com.lowdragmc.lowdraglib.rei.ModularDisplay;
@@ -34,6 +35,11 @@ public class MultiblockInfoDisplayCategory extends ModularUIDisplayCategory<Mult
         public Optional<ResourceLocation> getDisplayLocation() {
             return Optional.of(definition.id());
         }
+
+        @Override
+        public void clearSlotWidgetHandler(SlotWidget slotW, int slotIndex) {
+            slotW.setDrawHoverOverlay(false);
+        }
     }
 
     public static final CategoryIdentifier<MultiblockInfoDisplay> CATEGORY = CategoryIdentifier
@@ -41,7 +47,7 @@ public class MultiblockInfoDisplayCategory extends ModularUIDisplayCategory<Mult
     private final Renderer icon;
 
     public MultiblockInfoDisplayCategory() {
-        this.icon = IGui2Renderer.toDrawable(new ResourceTexture("textures/gui/multiblock_info_page.png"));
+        this.icon = IGui2Renderer.toDrawable(new ResourceTexture("mbd2:textures/gui/multiblock_info_page.png"));
     }
 
     public static void registerDisplays(DisplayRegistry registry) {


### PR DESCRIPTION
This PR is actually a follow-up to https://github.com/Low-Drag-MC/LDLib-MultiLoader/pull/57
<img width="1872" height="1110" alt="image" src="https://github.com/user-attachments/assets/d80c9402-8820-4e6e-92d5-2311a158620a" />
related to https://github.com/Low-Drag-MC/LDLib-MultiLoader/issues/102

PS: There is still have a bug about it, the tooltip of predicate item doesn't show up, but perhaps it should be resolved in LDLib.
