### PR TITLE
Add Valkyrien Skies compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -75,6 +75,12 @@ dependencies {
     // Applied Energistics 2
     implementation fg.deobf("appeng:appliedenergistics2-forge:${applied_energistics_version}")
 
+    // Valkyrien Skies 2
+    compileOnly fg.deobf("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}")
+    compileOnly("org.valkyrienskies.core:api:${vs_core_version}")
+    compileOnly("org.joml:joml:1.10.4")
+    compileOnly("org.joml:joml-primitives:1.10.0")
+
     // Blood Magic
 //    implementation fg.deobf("com.wayoftime.bloodmagic:BloodMagic:${blood_magic_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.jvmargs=-Xmx6G
 org.gradle.daemon=false
 
-
 minecraft_version=1.20.1
 minecraft_version_range=[1.20.1,1.21)
 forge_version=47.4.10
@@ -55,3 +54,5 @@ applied_energistics_version=15.0.18
 jade_version=11.12.3+forge
 embeddium_version=0.3.31+mc1.20.1
 oculus_version=1.20.1-1.8.0
+vs2_version=2.4.11+c1e5b68ef8
+vs_core_version=1.1.0+cf208d8b56

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -66,4 +66,17 @@ repositories {
             includeGroup 'com.gregtechceu.gtceu'
         }
     }
+    maven {
+        name = "Valkyrien Skies"
+        url = "https://maven.valkyrienskies.org"
+        content {
+            excludeGroup("org.spongepowered")
+            excludeGroup("net.jodah")
+            excludeGroup("net.minecraftforge")
+        }
+    }
+    maven {
+        name = "Kotlin for Forge"
+        url = "https://thedarkcolour.github.io/KotlinForForge/"
+    }
 }

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ApplyForceNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ApplyForceNode.java
@@ -1,0 +1,77 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.Configurable;
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+
+import net.minecraft.core.BlockPos;
+
+import org.joml.Vector3d;
+import org.joml.Vector3f;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
+import org.valkyrienskies.mod.common.util.GameToPhysicsAdapter;
+
+@LDLRegister(name = "apply force to ship", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class ApplyForceNode extends LinearTriggerNode {
+    public enum Space {
+        BODY,
+        MODEL,
+        WORLD;
+    }
+
+	@InputPort
+	public Ship ship;
+
+	@InputPort(name = "direction xyz", tips = {"if you're getting this from a block Direction, you might ", "want to use transform rotation on it first (with shipToWorld)"})
+	public Vector3f dir_xyz;
+
+	@InputPort(tips = "force multiplier, e.g. strength")
+	public int force;
+
+	@InputPort(name = "location based", tips = "is force applied at the 'pos xyz', else the force will be global")
+	public boolean location_based = true;
+
+    @InputPort(name = "pos xyz")
+    public Vector3f pos_xyz;
+
+    @InputPort(
+            name = "offset xyz",
+            tips = {
+                "due to floating point precision, it can be difficult to add a small offset to your shipyard positions.",
+                "this value will be added to your xyz input before applying the force at that position. ",
+                "This is useful to apply forces at the center of a block, where a 0.5 offset is necessary."
+            }
+    )
+    public Vector3f offset_xyz;
+
+    @Configurable(name = "coordinate space", tips = {"BODY = offset from COM", "MODEL = shipyard block position", "WORLD = world block position, e.g. nearby the ship"})
+    public Space coordinateSpace = Space.MODEL;
+
+	@Override
+	protected void process() {
+		if (ship != null && pos_xyz != null && force != 0) {
+
+			GameToPhysicsAdapter gtpa = ValkyrienSkiesMod.getOrCreateGTPA(ship.getChunkClaimDimension());
+            Vector3d dir = new Vector3d(dir_xyz.x, dir_xyz.y, dir_xyz.z);
+
+            long id = ship.getId();
+            Vector3d forceVec = dir.mul(force);
+            Vector3d posVec = new Vector3d(pos_xyz);
+            if (offset_xyz != null) {
+                posVec.add(offset_xyz);
+            }
+
+            if (location_based) {
+                switch (coordinateSpace) {
+                    case BODY -> gtpa.applyWorldForceToBodyPos(id, forceVec, posVec);
+                    case MODEL -> gtpa.applyWorldForceToModelPos(id, forceVec, posVec);
+                    case WORLD -> gtpa.applyWorldForce(id, forceVec, posVec);
+                }
+            } else {
+                gtpa.applyInvariantForce(ship.getId(), dir.mul(force));
+            }
+        }
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ApplyTorqueNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ApplyTorqueNode.java
@@ -1,0 +1,51 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.Configurable;
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+import org.joml.Vector3d;
+import org.joml.Vector3f;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
+import org.valkyrienskies.mod.common.util.GameToPhysicsAdapter;
+
+@LDLRegister(name = "apply torque to ship", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class ApplyTorqueNode extends LinearTriggerNode {
+    public enum Space {
+        BODY,
+        MODEL,
+        WORLD;
+    }
+
+	@InputPort
+	public Ship ship;
+
+	@InputPort(name = "torque xyz", tips = {"if you're getting this from a block Direction, you might ", "want to use transform rotation on it first (with shipToWorld)"})
+	public Vector3f torque_xyz;
+
+	@InputPort(tips = "torque multiplier, aka strength")
+	public int strength;
+
+    @Configurable(name = "coordinate space", tips = {"BODY = relative to COM", "MODEL = relative to shipyard", "WORLD = relative to world"})
+    public Space coordinateSpace = Space.MODEL;
+
+	@Override
+	protected void process() {
+		if (ship != null && torque_xyz != null && strength != 0) {
+
+			GameToPhysicsAdapter gtpa = ValkyrienSkiesMod.getOrCreateGTPA(ship.getChunkClaimDimension());
+            Vector3d torque = new Vector3d(torque_xyz.x, torque_xyz.y, torque_xyz.z);
+
+            long id = ship.getId();
+            Vector3d forceVec = torque.mul(strength);
+
+            switch (coordinateSpace) {
+                case BODY -> gtpa.applyBodyTorque(id, forceVec);
+                case MODEL -> gtpa.applyModelTorque(id, forceVec);
+                case WORLD -> gtpa.applyWorldTorque(id, forceVec);
+            }
+
+        }
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/GetShipNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/GetShipNode.java
@@ -1,0 +1,33 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+import com.lowdragmc.mbd2.common.machine.MBDMachine;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@LDLRegister(name = "get ship", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class GetShipNode extends LinearTriggerNode {
+	@InputPort
+	public Level level;
+	@InputPort
+	public Vector3f xyz;
+	@OutputPort
+	public Ship ship;
+
+	@Override
+	protected void process() {
+		if (xyz != null && level != null) {
+			ship = VSGameUtilsKt.getShipManagingPos(level, new BlockPos((int) xyz.x, (int) xyz.y, (int) xyz.z));
+		}
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/PositionOnShipNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/PositionOnShipNode.java
@@ -1,0 +1,32 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+import com.lowdragmc.mbd2.common.machine.MBDMachine;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@LDLRegister(name = "is position on ship", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class PositionOnShipNode extends LinearTriggerNode {
+	@InputPort
+	public Level level;
+	@InputPort
+	public Vector3i xyz;
+	@OutputPort(name = "on ship")
+	public boolean onShip;
+
+	@Override
+	protected void process() {
+		if (xyz != null) {
+			onShip = VSGameUtilsKt.getShipManagingPos(level, new BlockPos(xyz.x, xyz.y, xyz.z)) != null;
+		}
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/SetStaticNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/SetStaticNode.java
@@ -1,0 +1,30 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import org.joml.Vector3f;
+import org.valkyrienskies.core.api.ships.ServerShip;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@LDLRegister(name = "set ship static", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class SetStaticNode extends LinearTriggerNode {
+	@InputPort
+	public Ship ship;
+
+	@InputPort(name = "is static", tips = {"true = ship is frozen in place.", "get the current ship 'is static' from ship info"})
+	public boolean isStatic;
+
+	@Override
+	protected void process() {
+		if (ship != null) {
+			if (ship instanceof ServerShip serverShip) {
+                serverShip.setStatic(isStatic);
+            }
+		}
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ShipBoundsNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ShipBoundsNode.java
@@ -1,0 +1,44 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+import net.minecraft.world.phys.AABB;
+import org.joml.Matrix4dc;
+import org.joml.Vector3d;
+import org.joml.Vector3f;
+import org.joml.primitives.AABBdc;
+import org.joml.primitives.AABBic;
+import org.valkyrienskies.core.api.ships.ServerShip;
+import org.valkyrienskies.core.api.ships.Ship;
+
+@LDLRegister(name = "ship bounds", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class ShipBoundsNode extends LinearTriggerNode {
+	@InputPort
+	public Ship ship;
+
+	@OutputPort(tips = "minimum xyz of the ships bounds in ship space", name = "ship from")
+	public Vector3f ship_from;
+    @OutputPort(tips = "maximum xyz of the ships bounds in ship space", name = "ship to")
+	public Vector3f ship_to;
+
+    @OutputPort(tips = "minimum xyz of the ships bounds in world space", name = "world from")
+    public Vector3f world_from;
+    @OutputPort(tips = "maximum xyz of the ships bounds in world space", name = "world to")
+    public Vector3f world_to;
+
+	@Override
+	protected void process() {
+		if (ship != null) {
+            AABBic shipAABB = ship.getShipAABB();
+            if (shipAABB != null) {
+                ship_from = new Vector3f(shipAABB.minX(), shipAABB.minY(), shipAABB.minZ());
+                ship_to = new Vector3f(shipAABB.maxX(), shipAABB.maxY(), shipAABB.maxZ());
+            }
+            AABBdc worldAABB = ship.getWorldAABB();
+            world_from = new Vector3d(worldAABB.minX(), worldAABB.minY(), worldAABB.minZ()).get(new Vector3f());
+            world_to = new Vector3d(worldAABB.maxX(), worldAABB.maxY(), worldAABB.maxZ()).get(new Vector3f());
+        }
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ShipInfoNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/ShipInfoNode.java
@@ -1,0 +1,83 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+import com.lowdragmc.mbd2.common.machine.MBDMachine;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+
+import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix4dc;
+import org.joml.Vector3dc;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.valkyrienskies.core.api.ships.ServerShip;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+import java.util.List;
+
+@LDLRegister(name = "ship info", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class ShipInfoNode extends LinearTriggerNode {
+
+	@InputPort
+	public Ship ship;
+
+	@OutputPort
+	public String slug;
+
+	@OutputPort
+	public Number id;
+
+	@OutputPort(tips = "linear velocity of the ship, in metres per second")
+	public Vector3f velocity;
+
+    @OutputPort(tips = "rotational velocity of the ship, in radians per second", name = "angular velocity")
+    public Vector3f angularVelocity;
+
+    @OutputPort(tips = "weight of the ship, in kg. weight is null on client")
+    public Number mass;
+
+    @OutputPort(tips = "is the ship static. always false on client", name = "is static")
+    public boolean isStatic;
+
+    @OutputPort(tips = "the xyz of the center of mass in ship space. null on client", name = "center of mass xyz")
+    public Vector3f centerOfMass;
+
+    @OutputPort(tips = {"whether this ship variable is server-side", "handy for making sure you don't get the client defaults", "for isStatic and other values"}, name = "is server")
+    public boolean isServer;
+
+	@OutputPort(name = "ship to world transform")
+	public Matrix4dc shipToWorld;
+
+	@OutputPort(name = "world to ship transform")
+	public Matrix4dc worldToShip;
+
+	@Override
+	protected void process() {
+		if (ship != null) {
+			slug = ship.getSlug();
+			id = ship.getId();
+
+            isStatic = false;
+            isServer = false;
+
+            velocity = ship.getVelocity().get(new Vector3f());
+            angularVelocity = ship.getAngularVelocity().get(new Vector3f());
+
+			worldToShip = ship.getTransform().getWorldToShip();
+			shipToWorld = ship.getTransform().getShipToWorld();
+
+            if (ship instanceof ServerShip serverShip) {
+                isServer = true;
+                mass = serverShip.getInertiaData().getMass();
+                isStatic = serverShip.isStatic();
+                centerOfMass = serverShip.getInertiaData().getCenterOfMass().get(new Vector3f());
+            }
+		}
+	}
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/TransformPosNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/TransformPosNode.java
@@ -1,0 +1,31 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+
+import org.joml.Matrix4dc;
+import org.joml.Vector3d;
+import org.joml.Vector3f;
+
+@LDLRegister(name = "transform position", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class TransformPosNode extends LinearTriggerNode {
+	@InputPort(tips = "ship transform to use, get from ship info")
+	public Matrix4dc transform;
+
+	@InputPort(name = "position xyz")
+	public Vector3f xyz;
+
+	@OutputPort(name = "transformed pos xyz")
+	public Vector3f new_xyz;
+
+	@Override
+	protected void process() {
+		if (transform != null && xyz != null) {
+			Vector3d newPos = transform.transformPosition(new Vector3d(xyz));
+			new_xyz = newPos.get(new Vector3f());
+		}
+	}
+
+}

--- a/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/TransformRotNode.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/valkyrienskies/TransformRotNode.java
@@ -1,0 +1,30 @@
+package com.lowdragmc.mbd2.integration.valkyrienskies;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.InputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.annotation.OutputPort;
+import com.lowdragmc.lowdraglib.gui.graphprocessor.data.trigger.LinearTriggerNode;
+
+import org.joml.Matrix4dc;
+import org.joml.Vector3d;
+import org.joml.Vector3f;
+
+@LDLRegister(name = "transform direction", group = "graph_processor.node.mbd2.machine.valkyrienskies", modID = "valkyrienskies")
+public class TransformRotNode extends LinearTriggerNode {
+	@InputPort(tips = "ship transform to use, get from ship info")
+	public Matrix4dc transform;
+
+	@InputPort(name = "direction xyz")
+	public Vector3f xyz;
+
+	@OutputPort(name = "transformed dir xyz")
+	public Vector3f new_xyz;
+
+	@Override
+	protected void process() {
+		if (transform != null && xyz != null) {
+			Vector3d newRot = transform.transformDirection(new Vector3d(xyz), new Vector3d());
+			new_xyz = newRot.get(new Vector3f());
+		}
+	}
+}

--- a/src/main/resources/assets/mbd2/lang/en_us.json
+++ b/src/main/resources/assets/mbd2/lang/en_us.json
@@ -919,6 +919,8 @@
     "graph_processor.node.mbd2.machine.photon.force_death.tips.2": "if true, emitter will remove and particles from rendering and ticking immediately when the fx was removed.",
     "graph_processor.node.mbd2.machine.photon.replace_existing.tips.0": "If true, the existing fx with the same identifier will be replaced.",
     "graph_processor.node.mbd2.machine.photon.replace_existing.tips.1": "If false, this fx won't shown if the existing fx with the same identifier found.",
+    "graph_processor.node.mbd2.machine.valkyrienskies": "Valkrien Skies",
+
     "pattern_preview.page": "switch pages",
     "pattern_preview.layer": "switch layers",
     "pattern_preview.formed": "switch structure formed",


### PR DESCRIPTION
Its been just over a year since [I said I would make VS compat](https://github.com/Low-Drag-MC/Multiblocked2/issues/29#issuecomment-2480675689).... but I've finally done it.

This PR adds nodes for Valkyrien Skies for use in the graph editor, including:
- apply torque to ship
- is position on ship
- transform position
- ship bounds
- set ship static
- get ship
- apply force to ship
- ship info
- transform direction
('ship' is what the physics objects in VS are called)

These nodes (which I've tested thoroughly) would allow for things like multiblock VS thrusters, or a machine raycast taking ship rotation into account, as well as many more ideas I'm sure people will find.