### PR TITLE
Fixed incorrect EMI recipe id

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/emi/MBDRecipeTypeEmiCategory.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/emi/MBDRecipeTypeEmiCategory.java
@@ -45,16 +45,18 @@ public class MBDRecipeTypeEmiCategory extends EmiRecipeCategory {
         @Getter
         private final MBDRecipeTypeEmiCategory category;
         private final MBDRecipe recipe;
+        private final ResourceLocation id;
 
-        public MBDEmiRecipe(MBDRecipeTypeEmiCategory category, MBDRecipe recipe) {
+        public MBDEmiRecipe(MBDRecipeTypeEmiCategory category, MBDRecipe recipe, ResourceLocation id) {
             super(self -> ModularUI.of(((MBDEmiRecipe) self).recipe.recipeType.createRecipeUI(((MBDEmiRecipe) self).recipe)));
             this.category = category;
             this.recipe = recipe;
+            this.id = id;
         }
 
         @Override
         public @Nullable ResourceLocation getId() {
-            return recipe.id;
+            return id;
         }
 
         @Override
@@ -80,7 +82,7 @@ public class MBDRecipeTypeEmiCategory extends EmiRecipeCategory {
                 var recipe = holder.value();
                 if (recipe.isXEIHidden) continue;
                 if (seen.add(holder.id())) {
-                    registry.addRecipe(new MBDEmiRecipe(category, recipe));
+                    registry.addRecipe(new MBDEmiRecipe(category, recipe, holder.id()));
                 }
             }
         }


### PR DESCRIPTION
## Description
In EMI Dev Mode, EMI says the following for every MBD recipe:
> Recipe ID could not be found in the recipe manager, but is not synthetic

As it turns out, this is likely due to EMI using reference equality check instead of value equality check for recipe ids when looking for invalid recipes. As `MBDEmiRecipe` uses `MBDRecipe#id`, it differs from `RecipeHolder#id` referentially, even though actual contents of both `ResourceLocation` are the same.

This PR replaces `MBDRecipe#id` with `RecipeHolder#id` inside `MBDEmiRecipe`, fixing the issue above.

### Before/After
<img width="410" height="305" alt="image" src="https://github.com/user-attachments/assets/4ec577ec-132e-4d91-9813-15a2da777041" />
<img width="346" height="305" alt="image" src="https://github.com/user-attachments/assets/f4289f14-a2ee-4d6d-9783-fe8346834ce4" />
