### PR TITLE
Fixed KubeJS inputChemical/outputChemical parsing for Mekanism

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/mekanism/SerializerChemicalStackIngredient.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/mekanism/SerializerChemicalStackIngredient.java
@@ -3,14 +3,18 @@ package com.lowdragmc.mbd2.integration.mekanism;
 import com.lowdragmc.mbd2.api.recipe.content.ContentModifier;
 import com.lowdragmc.mbd2.api.recipe.content.IContentSerializer;
 import com.mojang.serialization.Codec;
+import mekanism.api.MekanismAPI;
 import mekanism.api.chemical.Chemical;
 import mekanism.api.chemical.ChemicalStack;
 import mekanism.api.recipes.ingredients.ChemicalStackIngredient;
 import mekanism.api.recipes.ingredients.chemical.ChemicalIngredient;
+import mekanism.api.recipes.ingredients.creator.IChemicalIngredientCreator;
+import mekanism.api.recipes.ingredients.creator.IChemicalStackIngredientCreator;
 import mekanism.api.recipes.ingredients.creator.IngredientCreatorAccess;
 import net.minecraft.core.Holder;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 
 @SuppressWarnings("removal")
@@ -22,7 +26,7 @@ public class SerializerChemicalStackIngredient implements IContentSerializer<Che
     private SerializerChemicalStackIngredient() {}
 
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
     public ChemicalStackIngredient of(Object o) {
         if (o instanceof ChemicalStackIngredient ingredient) {
             return ingredient;
@@ -45,7 +49,33 @@ public class SerializerChemicalStackIngredient implements IContentSerializer<Che
         if (o instanceof TagKey<?> tag) {
             return new ChemicalStackIngredient(IngredientCreatorAccess.chemical().tag((TagKey<Chemical>) tag), DEFAULT_AMOUNT);
         }
+        if (o instanceof CharSequence) {
+            return parseString(o.toString());
+        }
         return fallback();
+    }
+
+    private static ChemicalStackIngredient parseString(String str) {
+        long amount = DEFAULT_AMOUNT;
+        int x = str.indexOf('x');
+        if (x > 0 && x < str.length() - 2 && str.charAt(x + 1) == ' ') {
+            try {
+                amount = Long.parseLong(str.substring(0, x).trim());
+                str = str.substring(x + 2).trim();
+            } catch (NumberFormatException ignore) {
+            }
+        }
+        if (str.startsWith("#")) {
+            var tag = TagKey.create(MekanismAPI.CHEMICAL_REGISTRY_NAME, ResourceLocation.parse(str.substring(1)));
+            return new ChemicalStackIngredient(IngredientCreatorAccess.chemical().tag(tag), Math.max(1L, amount));
+        }
+        var id = ResourceLocation.parse(str);
+        if (!MekanismAPI.CHEMICAL_REGISTRY.containsKey(id)) {
+            throw new IllegalStateException("Invalid chemical input: " + str);
+        }
+        var chemical = MekanismAPI.CHEMICAL_REGISTRY.get(id);
+
+        return new ChemicalStackIngredient(IngredientCreatorAccess.chemical().of(chemical.getAsHolder()), Math.max(1L, amount));
     }
 
     private static ChemicalStackIngredient fallback() {


### PR DESCRIPTION
## Description
On MBD2 1.21.1, `inputChemical`/`outputChemical` in `MBDRecipeJS` lack `CharSequence` parsing. This [exists on MBD2 1.20.1](https://github.com/Low-Drag-MC/Multiblocked2/blob/4b290c7d100245155bd4468aa3b8036c22e8eefa/src/main/java/com/lowdragmc/mbd2/integration/mekanism/MekanismChemicalRecipeCapability.java#L242-L262), so I assume this is just a post-port oversight.

This PR brings back CharSequence parsing, and also adds support for chemical tags.