### PR TITLE
Fixed capContent always returning non-null empty handler list

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/trait/SimpleCapabilityTraitDefinition.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/trait/SimpleCapabilityTraitDefinition.java
@@ -67,7 +67,7 @@ public abstract class SimpleCapabilityTraitDefinition<T, C extends @Nullable Obj
                     contents.add(typedTrait.getCapContent(typedTrait.getCapabilityIO(context)));
                 }
             }
-            return merge(contents);
+            return contents.isEmpty() ? null : merge(contents);
         }
 
         /**
@@ -93,7 +93,7 @@ public abstract class SimpleCapabilityTraitDefinition<T, C extends @Nullable Obj
                 collectProxiedContents(mbdController, staticProxies, partFront, side, contents);
                 collectProxiedContents(mbdController, predicateProxies, partFront, side, contents);
             }
-            return merge(contents);
+            return contents.isEmpty() ? null : merge(contents);
         }
 
         @SuppressWarnings("unchecked")
@@ -110,7 +110,7 @@ public abstract class SimpleCapabilityTraitDefinition<T, C extends @Nullable Obj
             Direction side = context instanceof Direction d ? d : null;
             List<T> contents = new ArrayList<>();
             collectProxiedContents(controller, caps, front, side, contents);
-            return merge(contents);
+            return contents.isEmpty() ? null : merge(contents);
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Description
Right now, `SimpleCapabilityTraitDefinition#getCapContent/getProxiedCapContent/getProxyPartCapContent` always return a non-null empty handler list whenever contents list is empty.

This has two potential issues: 
1. Unnecessary allocation of a handler list. As we already know that `contents` is empty, this makes downstream handler effectively no-op.
2. Prevents NeoForge's other capability providers lookup. NeoForge [iterates over all available providers for a specific block](https://github.com/neoforged/NeoForge/blob/2f185f98b868259fef706d7cb6af1c3c3fcd55f1/src/main/java/net/neoforged/neoforge/capabilities/BlockCapability.java#L214-L218), and because MBD returns a non-null empty handler list, lookup stops at it (Neo expects `null` when a provider is not suitable). This prevents addons from adding custom capabilities for the same capability type.

## Solution
Whenever `SimpleCapabilityTraitDefinition` acknowledges that it has no trait capContent to serve - return `null`. This hands off next suitable capability provider lookup back to NeoForge.