### PR TITLE
Fixed KubeJS recipes not working on dedicated servers

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/kubejs/recipe/MBDRecipeSchema.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/kubejs/recipe/MBDRecipeSchema.java
@@ -44,7 +44,6 @@ import java.util.function.Consumer;
 public interface MBDRecipeSchema {
     RecipeSchema SCHEMA = new RecipeSchema()
             .factory(new KubeRecipeFactory(MBD2.id("mbd_recipe"), MBDRecipeJS.class, MBDRecipeJS::new))
-            .typeOverride(MBD2.id("mbd_recipe_serializer"))
             .constructor();
 
     class MBDRecipeJS extends KubeRecipe {


### PR DESCRIPTION
## Description
Recently accepted PR https://github.com/Low-Drag-MC/Multiblocked2/pull/204 contains an oversight. If recipes are created via KubeJS on a dedicated server - they will not work. This PR fixes the issue. I've tested recipes added via both datapacks and KubeJS scripts - looks good.

## Cause
This is due to misused `typeOverride`, which coerces all recipes to have a dummy serializer, meaning they won't be found by corresponding recipe types. Removing `typeOverride` allows type to have the same id as recipe type itself.