### PR TITLE
Fixed incorrect recipe slots bindings for 10+ indexes

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/api/recipe/MBDRecipeType.java
+++ b/src/main/java/com/lowdragmc/mbd2/api/recipe/MBDRecipeType.java
@@ -452,8 +452,8 @@ public class MBDRecipeType implements RecipeType<MBDRecipe>, INBTSerializable<Co
         values.forEach((cap, contents) -> {
             for (int i = 0; i < contents.size(); i++) {
                 var content = contents.get(i);
-                var id = content.uiName.isEmpty() ? "@%s_%s_%d".formatted(cap.name, io.name, i) : content.uiName;
-                ui.selectRegex(Pattern.quote(id)).forEach(widget -> {
+                var id = content.uiName.isEmpty() ? "^@%s_%s_%d$".formatted(cap.name, io.name, i) : Pattern.quote(content.uiName);
+                ui.selectRegex(id).forEach(widget -> {
                     ((RecipeCapability) cap).bindXEIWidget(widget, content, io);
                     var tooltips = new ArrayList<Component>();
                     content.appendTooltip(tooltips);


### PR DESCRIPTION
## Description
Widget IDs have the following id format: `@<capability>_<io>_<index>`

On 1.20.1, id used to be anchored by `^` and `$`, which effectively made it a **full match**, which is good.

On 1.21.1, this behavior changed. Due to missing anchors, search turned into a **substring match**. This made ids like `item_import_1` also match `item_import_10`, `item_import_18`, etc.

This PR brings back [1.20.1 behavior](https://github.com/Low-Drag-MC/Multiblocked2/blob/4b290c7d100245155bd4468aa3b8036c22e8eefa/src/main/java/com/lowdragmc/mbd2/api/recipe/MBDRecipeType.java#L454).

## Demo
### Recipe UI setup
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bf25cfe2-efca-4759-8a4d-3f85ad0a4f9c" />

### Without a fix
Slot 2 matched `@item_import_1`, which is correct. But slots 11-16 also matched `@item_import_1`, not their `@item_import_10` - `@item_import_15` counterparts. This is due a substring match.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b53055d2-d93a-450c-b3aa-d55bba998089" />

### With a fix
Each slot match their exact counterparts: slot 2 matched `@item_import_1`, slot 11 matched `@item_import_10`.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7d96d6b7-3e8a-4c06-ac98-3f7d37e67938" />
