### PR TITLE
Fixed Mekanism `ChemicalSlot` rendering for textured chemicals

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/mekanism/ChemicalSlot.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/mekanism/ChemicalSlot.java
@@ -273,7 +273,7 @@ public class ChemicalSlot extends BindableUIElement<ChemicalStack> {
     private static void drawChemical(GuiGraphics graphics, ChemicalStack stack, float x, float y, float width, float height) {
         TextureAtlasSprite sprite = MekanismRenderer.getChemicalTexture(stack);
         if (sprite == null) return;
-        int color = stack.getChemicalColorRepresentation() | 0xff000000;
+        int color = stack.getChemicalTint() | 0xff000000;
         RenderSystem.enableBlend();
         int xTiles = (int) (width / 16);
         float xRemainder = width - xTiles * 16f;


### PR DESCRIPTION
## Description
`ChemicalSlot` rendering uses `ChemicalStack#getChemicalColorRepresentation`, which works with tiny-only chemicals (e.g. hydrogen), but doesn't with textured chemical (e.g. bio). Therefore, textured chemicals appear a lot darker in UI.

This PR replaces `ChemicalStack#getChemicalColorRepresentation` with `ChemicalStack#getChemicalTint`, which blends colors correctly for both chemical types.

## Demo
### Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/59c5f755-06f3-43fd-90df-75b31f41eb7f" />

### After

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2e9acde0-7cda-48aa-921b-a17e24d9b74d" />
