### PR TITLE
EMI-related enhancements

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/integration/emi/MultiblockInfoEmiCategory.java
+++ b/src/main/java/com/lowdragmc/mbd2/integration/emi/MultiblockInfoEmiCategory.java
@@ -47,7 +47,7 @@ public class MultiblockInfoEmiCategory extends EmiRecipeCategory {
 
         @Override
         public @Nullable ResourceLocation getId() {
-            return MBD2.id("multiblock_info/" + definition.id().getNamespace() + "/" + definition.id().getPath());
+            return MBD2.id("/multiblock_info/" + definition.id().getNamespace() + "/" + definition.id().getPath());
         }
 
         @Override

--- a/src/main/resources/assets/mbd2/lang/en_us.json
+++ b/src/main/resources/assets/mbd2/lang/en_us.json
@@ -797,6 +797,7 @@
   "editor.machine.multiblock.multiblock_shape_info.description.tips": "description displayed in XEI page",
   "editor.machine.multiblock.multiblock_shape_info.remove": "remove shape info",
   "mbd2.jei.multiblock_info": "Multiblock Info",
+  "emi.category.mbd2.multiblock_info": "Multiblock Info",
   "ldlib2.renderer.geckolib": "Geckolib Model",
   "geckolib_renderer.scale_width": "Scale Width",
   "geckolib_renderer.scale_height": "Scale Height",

--- a/src/main/resources/assets/mbd2/lang/ja_jp.json
+++ b/src/main/resources/assets/mbd2/lang/ja_jp.json
@@ -612,6 +612,7 @@
     "editor.machine.multiblock.multiblock_shape_info.description.tips": "XEIページに表示される説明",
     "editor.machine.multiblock.multiblock_shape_info.remove": "形状情報を削除",
     "mbd2.jei.multiblock_info": "マルチブロック情報",
+    "emi.category.mbd2.multiblock_info": "マルチブロック情報",
 
     "ldlib2.renderer.geckolib": "Geckolibモデル",
     "geckolib_renderer.scale_width": "スケール幅",

--- a/src/main/resources/assets/mbd2/lang/ru_ru.json
+++ b/src/main/resources/assets/mbd2/lang/ru_ru.json
@@ -793,7 +793,8 @@
     "editor.machine.multiblock.multiblock_shape_info.description": "описание",
     "editor.machine.multiblock.multiblock_shape_info.description.tips": "описание, отображаемое в XEI страница",
     "editor.machine.multiblock.multiblock_shape_info.remove": "удалить информацию о форме",
-    "mbd2.jei.multiblock_info": "Информация о мультиблоке",
+    "mbd2.jei.multiblock_info": "О мультиблоке",
+    "emi.category.mbd2.multiblock_info": "О мультиблоке",
 
     "ldlib2.renderer.geckolib": "Модель Geckolib",
     "geckolib_renderer.scale_width": "Ширина шкалы",

--- a/src/main/resources/assets/mbd2/lang/zh_cn.json
+++ b/src/main/resources/assets/mbd2/lang/zh_cn.json
@@ -854,6 +854,7 @@
     "editor.machine.multiblock.multiblock_shape_info.description.tips": "XEI页面中显示的描述",
     "editor.machine.multiblock.multiblock_shape_info.remove": "移除形状信息",
     "mbd2.jei.multiblock_info": "多方块信息",
+    "emi.category.mbd2.multiblock_info": "多方块信息",
 
     "ldlib2.renderer.geckolib": "Geckolib 模型",
     "geckolib_renderer.scale_width": "宽度缩放",


### PR DESCRIPTION
## Description
This is a small PR, which includes:
1. Usage of synthetic recipe ID for multiblock info category (as it is not in recipe manager and is purely for info display). Without it EMI warns about it.
2. Added missing EMI multiblock info category localization lines to all locales based on similar JEI line.