### PR TITLE
Fix gadgets item mode serialization

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/item/MBDGadgetsItem.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/item/MBDGadgetsItem.java
@@ -73,7 +73,7 @@ public class MBDGadgetsItem extends Item implements HeldItemUIMenuType.HeldItemU
 
         @Override
         public String getSerializedName() {
-            return "";
+            return name;
         }
     }
 


### PR DESCRIPTION
## Description
`MBDGadgetsItem.Mode` enum implements `StringRepresentable`, but `getSerializedName` always returned empty string instead of `name`, meaning the mode was never properly persisted.