### PR TITLE
Fix fog affecting in-world preview rendering

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/client/renderer/MultiblockInWorldPreviewRenderer.java
+++ b/src/main/java/com/lowdragmc/mbd2/client/renderer/MultiblockInWorldPreviewRenderer.java
@@ -312,6 +312,10 @@ public class MultiblockInWorldPreviewRenderer {
                 shaderInstance.setDefaultUniforms(VertexFormat.Mode.QUADS,
                         modelView, event.getProjectionMatrix(), Minecraft.getInstance().getWindow());
 
+                if (shaderInstance.FOG_START != null) {
+                    shaderInstance.FOG_START.set(Float.MAX_VALUE);
+                }
+
                 RenderSystem.setShaderColor(1, 1, 1, 1);
                 if (layer == RenderType.translucent()) { // TRANSLUCENT
                     RenderSystem.enableBlend();


### PR DESCRIPTION
## Description
Whenever an in-world multiblock preview is rendered far away from 0,0 coordinates, the fog starts affecting it, causing noticeable visual artifacts. In MBD2 1.20.1, shader's `ShaderInstance#FOG_START` was set to `Float.MAX_VALUE`, but on 1.21 it's missing. Bringing back this setting fixes the issue.

## Screenshots
### Before the PR (multiblock placed at -260, -60, -40)
<img width="600" alt="Screenshot 2026-07-27 at 12 53 46" src="https://github.com/user-attachments/assets/23f71e99-7545-4d94-b5c8-42bb3d18c575" />

### After the PR (multiblock placed at -260, -60, -40)
<img width="600" alt="Screenshot 2026-07-27 at 12 52 36" src="https://github.com/user-attachments/assets/1ab335c9-9b5c-481f-9205-0907c3cc0cd1" />
