### PR TITLE
Fixed 2 recipe conditions causing the game to crash.

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/recipe/MachineLevelCondition.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/recipe/MachineLevelCondition.java
@@ -36,7 +36,7 @@ public class MachineLevelCondition extends RecipeCondition {
 
     @Override
     public Component getTooltips() {
-        return Component.translatable("recipe.condition.machine_level.tooltip", this.level);
+        return Component.translatable("recipe.condition.machine_level.tooltip", this.level.toString());
     }
 
     @Override

--- a/src/main/java/com/lowdragmc/mbd2/common/recipe/MachineNBTCondition.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/recipe/MachineNBTCondition.java
@@ -40,7 +40,7 @@ public class MachineNBTCondition extends RecipeCondition {
 
     @Override
     public Component getTooltips() {
-        return Component.translatable("recipe.condition.machine_custom_data.tooltip", this.data);
+        return Component.translatable("recipe.condition.machine_custom_data.tooltip", this.data.toString());
     }
 
     @Override


### PR DESCRIPTION
Fixed 2 recipe conditions causing the game to crash because of missing `.toString()` calls