### PR TITLE
Fix biome condition tooltip showing raw translation key instead of localized biome name

### DIFF
--- a/src/main/java/com/lowdragmc/mbd2/common/recipe/BiomeCondition.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/recipe/BiomeCondition.java
@@ -48,7 +48,9 @@ public class BiomeCondition extends RecipeCondition {
 
     @Override
     public Component getTooltips() {
-        return Component.translatable("recipe.condition.biome.tooltip", LocalizationUtils.format("biome.%s.%s", biome.getNamespace(), biome.getPath()));
+        String biomeKey = String.format("biome.%s.%s", biome.getNamespace(), biome.getPath());
+        return Component.translatable("recipe.condition.biome.tooltip",
+                                      Component.translatable(biomeKey));
     }
 
     @Override

--- a/src/main/java/com/lowdragmc/mbd2/common/recipe/BiomeCondition.java
+++ b/src/main/java/com/lowdragmc/mbd2/common/recipe/BiomeCondition.java
@@ -3,7 +3,6 @@ package com.lowdragmc.mbd2.common.recipe;
 import com.google.gson.JsonObject;
 import com.lowdragmc.lowdraglib.gui.editor.configurator.ConfiguratorGroup;
 import com.lowdragmc.lowdraglib.gui.editor.configurator.SearchComponentConfigurator;
-import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 import com.lowdragmc.mbd2.api.recipe.MBDRecipe;
 import com.lowdragmc.mbd2.api.recipe.RecipeCondition;
 import com.lowdragmc.mbd2.api.recipe.RecipeLogic;
@@ -48,9 +47,8 @@ public class BiomeCondition extends RecipeCondition {
 
     @Override
     public Component getTooltips() {
-        String biomeKey = String.format("biome.%s.%s", biome.getNamespace(), biome.getPath());
         return Component.translatable("recipe.condition.biome.tooltip",
-                                      Component.translatable(biomeKey));
+                                      Component.translatable("biome." + biome.toLanguageKey()));
     }
 
     @Override


### PR DESCRIPTION
The following content is vibecode, but I have built it and run tests, and it works. Apologies if this is an intrusion.## Describe the bug

In JEI/REI/EMI, the biome recipe condition tooltip displays the raw translation key
instead of the localized biome name, e.g. `Biome: biome.minecraft.deep_dark` instead of
`Biome: Deep Dark` (or `生物群系：深邃暗域` in zh_cn).

Adding a resource pack entry for `biome.minecraft.deep_dark` has no effect either.

## Root cause

`BiomeCondition#getTooltips` passed the **format template** `"biome.%s.%s"` to
`LocalizationUtils.format` as if it were a translation key:

```java
return Component.translatable("recipe.condition.biome.tooltip",
        LocalizationUtils.format("biome.%s.%s", biome.getNamespace(), biome.getPath()));
```

`"biome.%s.%s"` does not exist in any language file, so `I18n.get` falls back to the key
itself, and `String.format` then substitutes the namespace/path into that fallback —
producing the literal string `"biome.minecraft.deep_dark"`. The real biome translation key
is constructed but **never looked up**, which is also why resource pack overrides for it
never take effect.

## Fix

Build the actual translation key and resolve it with a nested translatable component:

```java
@Override
public Component getTooltips() {
    return Component.translatable("recipe.condition.biome.tooltip",
            Component.translatable("biome." + biome.toLanguageKey()));
}
```

Reasons for using a nested `Component.translatable` instead of `LocalizationUtils.format(key)`:

- `getTooltips()` is also invoked from server-side recipe logic (`MBDRecipe#checkConditions`).
  `Component.translatable` resolves lazily on the client at render time, while
  `LocalizationUtils.format` evaluates immediately and falls back to the raw key when
  called outside the client (`LDLib.isClient()` == false → `String.format(key)`).
- `toLanguageKey()` is already used in this codebase (`MBDRecipeTypeCategory#getTitle`).
- Removed the now-unused `LocalizationUtils` import.

## Result

| | Before | After |
|---|---|---|
| en_us | `Biome: biome.minecraft.deep_dark` | `Biome: Deep Dark` |
| zh_cn | `生物群系：biome.minecraft.deep_dark` | `生物群系：深邃暗域` |

Resource pack overrides for `biome.<namespace>.<path>` now work as expected.